### PR TITLE
Fixed print.cjs

### DIFF
--- a/print.cjs
+++ b/print.cjs
@@ -2,11 +2,12 @@ const puppeteer = require('puppeteer');
 const exiftool = require('node-exiftool');
 const ep = new exiftool.ExiftoolProcess();
 
-const PORT = process.argv[2] === '--dev' ? '3000' : '5000';
+const PORT = process.argv[2] === '--dev' ? '5173' : '4173';
 const OUT = process.argv[2] === '--dev' ? 'public' : 'dist';
 
 (async () => {
   const browser = await puppeteer.launch({
+    executablePath: 'google-chrome',
     dumpio: true,
     headless: true,
     args: ['--font-render-hinting=none', '--lang=en-GB'],


### PR DESCRIPTION
#8 
By default **svelte** `dev server` runs on **port 5173** and `preview server` on **port 4173**.

There are some bugs in the version of chromium puppeteer is using which is solved by adding:
    `executablePath: 'google-chrome',`
